### PR TITLE
パスワード変更画面編集#1

### DIFF
--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,15 +1,16 @@
 <h2>Forgot your password?</h2>
+<h2>パスワード再設定メール送信</h2>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "users/shared/error_messages", resource: resource %>
 
   <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.label :email, "メールアドレス" %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレスを入力してください" %>
   </div>
 
   <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
+    <%= f.submit "パスワード再設定メール送信" %>
   </div>
 <% end %>
 


### PR DESCRIPTION
・画面上部に `<h2>` タグで「パスワード再設定メール送信」という表示を追加
・email の部分を「メールアドレス」に変更
・メールアドレス入力欄のplaceholderに「メールアドレスを入力してください」と表示する
・「Send me reset password instructions」ボタンを「パスワード再設定メール送信」に変更
<img width="367" alt="スクリーンショット 2022-03-07 15 05 39" src="https://user-images.githubusercontent.com/75520329/156978967-a0f0867c-d98d-478c-8abb-8aaa601eb231.png">

