### PR TITLE
#4 パスワード再発行画面編集

### DIFF
--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -9,16 +9,16 @@
     <% if @minimum_password_length %>
       <em>(<%= @minimum_password_length %> characters minimum)</em><br />
     <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+    <%= f.password_field :password, autofocus: true, autocomplete: "new-password", placeholder:"パスワードを入力してください" %>
   </div>
 
   <div class="field">
     <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder:"パスワードを入力してください" %>
   </div>
 
   <div class="actions">
-    <%= f.submit "Change my password" %>
+    <%= f.submit t('devise.passwords.edit.change_my_password') %>
   </div>
 <% end %>
 


### PR DESCRIPTION
fix #4

パスワード再発行画面編集
・パスワード入力欄の placeholder 2つに「パスワードを入力して下さい」と表示
・ボタン名にパスワードを変更(i18nで実装)
<img width="336" alt="スクリーンショット 2022-03-07 16 26 46" src="https://user-images.githubusercontent.com/75520329/156988116-8a4f2589-764e-4181-8e44-101bffbea8d7.png">
<img width="549" alt="スクリーンショット 2022-03-07 16 27 11" src="https://user-images.githubusercontent.com/75520329/156988182-14087d97-83fe-408a-978a-a4c29f7e7a69.png">
